### PR TITLE
Adding apply_filters for each ad separately and for the whole html block

### DIFF
--- a/inc/dfads.class.php
+++ b/inc/dfads.class.php
@@ -248,8 +248,12 @@ class DFADS {
 				$html .= $this->open_tag( $ad_html, 'dfad dfad_pos_'.$i.$first_last.$args['ad_class'], $args['container_id'].'_ad_'.$ad->ID );
 			}
 			
-			// Get ad content.
-			$html .= $ad->post_content;
+			// Get ad content and apply filters.
+			$ad_post_content = $ad->post_content;
+			$ad_post_content = apply_filters('dfads_ad_post_content', $ad_post_content);
+			
+			// Append ad content to html block
+			$html .= $ad_post_content;
 			
 			// If ad_html is not empty, get the ads's closing tag.
 			if ( $ad_html != '') {
@@ -263,6 +267,8 @@ class DFADS {
 		if ( $container_html != '') {
 			$html .= $this->close_tag( $container_html );
 		}
+		
+		$html = apply_filters('dfads_ads_block_content', $html);
 		
 		return $html;
 	}


### PR DESCRIPTION
Regarding this #1 [Feature] Jetpack lazy-load compatibility

I have added 2 apply_filters calls. I thought that it would be great to keep it simple and filter only the final html block but also to give more flexibility to filter each ad separately for future use cases.

Have a look and let me know :)